### PR TITLE
v2: Platform-agnostic Sentry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,18 @@ To use this module:
 
 ```js
 import loglevel from "loglevel";
+import { BrowserClient } from "@sentry/browser";
+// Node.js: import { NodeClient } from "@sentry/node";
 import LoglevelSentry from "@toruslabs/loglevel-sentry";
 
 logger = loglevel.getLogger("__LOGGER_NAME__");
 
-const sentry = new LoglevelSentry({
-  /* Sentry opts */
-});
+const sentry = new LoglevelSentry(
+  new BrowserClient({
+    /* Sentry opts */
+  })
+  // Node.js: new NodeClient(...)
+);
 sentry.install(logger);
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,44 +1206,122 @@
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "5.30.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+          "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+          "requires": {
+            "@sentry/hub": "5.30.0",
+            "@sentry/minimal": "5.30.0",
+            "@sentry/types": "5.30.0",
+            "@sentry/utils": "5.30.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.30.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+          "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+          "requires": {
+            "@sentry/types": "5.30.0",
+            "@sentry/utils": "5.30.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.30.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+          "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+          "requires": {
+            "@sentry/hub": "5.30.0",
+            "@sentry/types": "5.30.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "5.30.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+          "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+        }
       }
     },
     "@sentry/core": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.0.1.tgz",
+      "integrity": "sha512-EoxgodyClasI8PA4GyU8Cp88W3R5ebpiLsE7fCcBcOU0DOBRkO8GAZ5IzfCDtYDJ50c9npivum5Oyj2wf8CXYw==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/hub": "6.0.1",
+        "@sentry/minimal": "6.0.1",
+        "@sentry/types": "6.0.1",
+        "@sentry/utils": "6.0.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.1.tgz",
+          "integrity": "sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg=="
+        },
+        "@sentry/utils": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.0.1.tgz",
+          "integrity": "sha512-bjGuBYnG6fulZ8mLhPGBxttNu96DCN6d7Glw2sfLf4aurn1kjJ/58hP2c8dH0OqWO5e+rGYTsZ5Dr5kqVKNGTg==",
+          "requires": {
+            "@sentry/types": "6.0.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/hub": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.0.1.tgz",
+      "integrity": "sha512-pGckNdhKcr7qYVXgSgA/QVGArATcmQu54YFAR5xTnkWVHpAwNmh0fc4CJCc4JBwS/LXSU1Y0nYiLQduVfnv8Cg==",
       "requires": {
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/types": "6.0.1",
+        "@sentry/utils": "6.0.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.1.tgz",
+          "integrity": "sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg=="
+        },
+        "@sentry/utils": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.0.1.tgz",
+          "integrity": "sha512-bjGuBYnG6fulZ8mLhPGBxttNu96DCN6d7Glw2sfLf4aurn1kjJ/58hP2c8dH0OqWO5e+rGYTsZ5Dr5kqVKNGTg==",
+          "requires": {
+            "@sentry/types": "6.0.1",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/minimal": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.0.1.tgz",
+      "integrity": "sha512-TQ/M5A+OsxtQJ8dzHwrclxKXpJNdQeM1PUoYhff4BvsOXJScvZb7+Yn0OUEQXEc9pSMNt62tnQy4ct80iAMTHw==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/types": "5.30.0",
+        "@sentry/hub": "6.0.1",
+        "@sentry/types": "6.0.1",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.1.tgz",
+          "integrity": "sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg=="
+        }
       }
     },
     "@sentry/types": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.1.tgz",
+      "integrity": "sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg=="
     },
     "@sentry/utils": {
       "version": "5.30.0",
@@ -1252,6 +1330,13 @@
       "requires": {
         "@sentry/types": "5.30.0",
         "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/types": {
+          "version": "5.30.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+          "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+        }
       }
     },
     "@types/eslint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1197,56 +1197,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@sentry/browser": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
-      "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
-      "requires": {
-        "@sentry/core": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@sentry/core": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-          "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
-          "requires": {
-            "@sentry/hub": "5.30.0",
-            "@sentry/minimal": "5.30.0",
-            "@sentry/types": "5.30.0",
-            "@sentry/utils": "5.30.0",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/hub": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-          "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
-          "requires": {
-            "@sentry/types": "5.30.0",
-            "@sentry/utils": "5.30.0",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/minimal": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-          "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
-          "requires": {
-            "@sentry/hub": "5.30.0",
-            "@sentry/types": "5.30.0",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/types": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-          "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
-        }
-      }
-    },
     "@sentry/core": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.0.1.tgz",
@@ -1322,22 +1272,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.0.1.tgz",
       "integrity": "sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg=="
-    },
-    "@sentry/utils": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
-      "requires": {
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@sentry/types": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-          "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
-        }
-      }
     },
     "@types/eslint": {
       "version": "7.2.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "dependencies": {
     "@sentry/browser": "^5.30.0",
+    "@sentry/core": "^6.0.1",
+    "@sentry/types": "^6.0.1",
     "loglevel": "^1.7.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@babel/runtime": "7.x"
   },
   "dependencies": {
-    "@sentry/browser": "^5.30.0",
     "@sentry/core": "^6.0.1",
     "@sentry/types": "^6.0.1",
     "loglevel": "^1.7.1"

--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -1,4 +1,5 @@
-import { Breadcrumb, BrowserClient, BrowserOptions, Hub, Severity } from "@sentry/browser";
+import { Hub } from "@sentry/core";
+import { Breadcrumb, Client, Severity } from "@sentry/types";
 import { Logger } from "loglevel";
 
 export default class LoglevelSentry {
@@ -6,8 +7,8 @@ export default class LoglevelSentry {
 
   private category: string;
 
-  constructor(opts: BrowserOptions) {
-    this.sentry = new Hub(new BrowserClient(opts));
+  constructor(client: Client) {
+    this.sentry = new Hub(client);
     this.category = "loglevel-sentry";
   }
 

--- a/types/src/loglevel-sentry.d.ts
+++ b/types/src/loglevel-sentry.d.ts
@@ -1,9 +1,9 @@
-import { BrowserOptions, Severity } from "@sentry/browser";
+import { Client, Severity } from "@sentry/types";
 import { Logger } from "loglevel";
 export default class LoglevelSentry {
     private sentry;
     private category;
-    constructor(opts: BrowserOptions);
+    constructor(client: Client);
     install(logger: Logger): void;
     setEnabled(enabled: boolean): void;
     isEnabled(): boolean;


### PR DESCRIPTION
This delegates Sentry client instantiation to users, allows platform-agnostic integrations.

#### Break changes:

- `LoglevelSentry` requires a Sentry `Client` instead of `BrowserOptions`.

This should be released as v2 to indicate above breaking changes.