### PR TITLE
Improve error translation

### DIFF
--- a/types/src/loglevel-sentry.d.ts
+++ b/types/src/loglevel-sentry.d.ts
@@ -10,6 +10,7 @@ export default class LoglevelSentry {
     log(level: Severity, ...msgs: unknown[]): void;
     trace(...msgs: unknown[]): void;
     error(err: Error, ...msgs: unknown[]): void;
+    private static translateError;
     private static translateMessage;
     private static translateLevel;
 }


### PR DESCRIPTION
This improves error translation logic from `log.error` to `Sentry.captureException` so that stack trace is properly reported to Sentry.