### PR TITLE
Add utils create-logger and redact-data

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export { createLogger } from "./src/create-logger";
 export { default } from "./src/loglevel-sentry";
+export { redactData } from "./src/redact-data";

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
+export { createLogger } from "./src/create-logger";
 export { default } from "./src/loglevel-sentry";

--- a/src/create-logger.ts
+++ b/src/create-logger.ts
@@ -1,0 +1,14 @@
+import { Client } from "@sentry/types";
+import loglevel, { Logger } from "loglevel";
+
+import SentryPlugin from "./loglevel-sentry";
+
+export function createLogger(name: string, client: Client): Logger {
+  const logger = loglevel.getLogger(name);
+  logger.enableAll();
+
+  const plugin = new SentryPlugin(client);
+  plugin.install(logger);
+
+  return logger;
+}

--- a/src/redact-data.ts
+++ b/src/redact-data.ts
@@ -1,0 +1,15 @@
+const defaultPattern = /(private|key|secret|authorization|address|email)+/i;
+
+export function redactData<T = unknown>(data: T, keyPattern = defaultPattern): T {
+  if (typeof data !== "object" || data === null) return data;
+
+  const keys = Object.keys(data);
+
+  for (const k of keys) {
+    const v = data[k];
+    if (typeof v === "string" && keyPattern.test(k)) data[k] = "***";
+    else data[k] = redactData(v, keyPattern);
+  }
+
+  return data;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,2 @@
 export { default } from "./src/loglevel-sentry";
+export { createLogger } from "./src/create-logger";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,3 @@
-export { default } from "./src/loglevel-sentry";
 export { createLogger } from "./src/create-logger";
+export { redactData } from "./src/redact-data";
+export { default } from "./src/loglevel-sentry";

--- a/types/src/create-logger.d.ts
+++ b/types/src/create-logger.d.ts
@@ -1,0 +1,3 @@
+import { Client } from "@sentry/types";
+import { Logger } from "loglevel";
+export declare function createLogger(name: string, client: Client): Logger;

--- a/types/src/redact-data.d.ts
+++ b/types/src/redact-data.d.ts
@@ -1,0 +1,1 @@
+export declare function redactData<T = unknown>(data: T, keyPattern?: RegExp): T;


### PR DESCRIPTION
This adds 2 utils:

- `createLogger`: quickly creates a logger (from `loglevel`) with Sentry enabled.
- `redactData`: recursively redacts values of sensitive keys.