### PR TITLE
Fix webpack library export

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,6 @@ const baseConfig = {
   output: {
     path: path.resolve(__dirname, "dist"),
     library: libraryName,
-    libraryExport: "default",
   },
   resolve: {
     extensions: [".ts", ".js", ".json"],


### PR DESCRIPTION
Previously, webpack is configured to export only `default`, update`libraryExport` to `''` so that all exported values are exposed.