### PR TITLE
Fix error when input logger has no name

### DIFF
--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -16,7 +16,7 @@ export default class LoglevelSentry {
     const defaultMethodFactory = logger.methodFactory;
 
     logger.methodFactory = (method, level, name) => {
-      this.category = name.toString();
+      if (name) this.category = name.toString();
 
       const defaultMethod = defaultMethodFactory(method, level, name);
 


### PR DESCRIPTION
If input logger has no name (`undefined`/`null`), this plugin will crash. This fixes the issue.