### PR TITLE
Fix incorrect messages input to default logger method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,13 @@ To use this module:
 
 ```js
 import loglevel from "loglevel";
-import { BrowserClient } from "@sentry/browser";
-// Node.js: import { NodeClient } from "@sentry/node";
-import LoglevelSentry from "@toruslabs/loglevel-sentry";
+import * as Sentry from "@sentry/browser";
+// Node.js: import * as Sentry from "@sentry/node";
+import LoglevelSentryPlugin from "@toruslabs/loglevel-sentry";
 
 logger = loglevel.getLogger("__LOGGER_NAME__");
 
-const sentry = new LoglevelSentry(
-  new BrowserClient({
-    /* Sentry opts */
-  })
-  // Node.js: new NodeClient(...)
-);
+const plugin = new LoglevelSentryPlugin(Sentry);
 sentry.install(logger);
 ```
 
@@ -77,7 +72,9 @@ sentry.install(logger);
 ```js
 import loglevel from "loglevel";
 import pino from "pino";
-import LoglevelSentry from "@toruslabs/loglevel-sentry";
+import * as Sentry from "@sentry/browser";
+// Node.js: import * as Sentry from "@sentry/node";
+import LoglevelSentryPlugin from "@toruslabs/loglevel-sentry";
 
 const logger = loglevel.getLogger("__LOGGER_NAME__");
 logger.methodFactory = (method, level, name) => {
@@ -85,9 +82,7 @@ logger.methodFactory = (method, level, name) => {
   return alt[method];
 };
 
-const sentry = new LoglevelSentry({
-  /* Sentry opts */
-});
+const sentry = new LoglevelSentryPlugin(Sentry);
 sentry.install(logger);
 ```
 
@@ -106,9 +101,7 @@ Though it isn't compulsory, it is recommended to call log functions with followi
 If you always want to monitor a specific event regardless of configured log level, use the plugin API:
 
 ```js
-const sentry = new LoglevelSentry({
-  /* Sentry opts */
-});
+const sentry = new LoglevelSentryPlugin(Sentry);
 sentry.install(logger);
 
 sentry.trace("this", "message", "will always be reported.");

--- a/src/create-logger.ts
+++ b/src/create-logger.ts
@@ -1,13 +1,12 @@
-import { Client } from "@sentry/types";
 import loglevel, { Logger } from "loglevel";
 
-import SentryPlugin from "./loglevel-sentry";
+import SentryPlugin, { Sentry } from "./loglevel-sentry";
 
-export function createLogger(name: string, client: Client): Logger {
+export function createLogger(name: string, sentry: Sentry): Logger {
   const logger = loglevel.getLogger(name);
   logger.enableAll();
 
-  const plugin = new SentryPlugin(client);
+  const plugin = new SentryPlugin(sentry);
   plugin.install(logger);
 
   return logger;

--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -28,17 +28,17 @@ export default class LoglevelSentry {
 
       switch (method) {
         case "error":
-          return (...msgs: unknown[]) => {
-            const [err, messages] = LoglevelSentry.translateError(msgs);
+          return (...args: unknown[]) => {
+            const [err, otherArgs] = LoglevelSentry.translateError(args);
 
-            this.error(err, ...messages);
-            if (defaultMethod) defaultMethod(err, ...messages);
+            this.error(err, ...otherArgs);
+            if (defaultMethod) defaultMethod(err, ...otherArgs);
           };
 
         default:
-          return (...msgs: unknown[]) => {
-            this.log(LoglevelSentry.translateLevel(method), ...msgs);
-            if (defaultMethod) defaultMethod(...msgs);
+          return (...args: unknown[]) => {
+            this.log(LoglevelSentry.translateLevel(method), ...args);
+            if (defaultMethod) defaultMethod(...args);
           };
       }
     };
@@ -54,41 +54,41 @@ export default class LoglevelSentry {
     return this.sentry.getCurrentHub().getClient().getOptions().enabled;
   }
 
-  log(level: Severity, ...msgs: unknown[]): void {
+  log(level: Severity, ...args: unknown[]): void {
     this.sentry.addBreadcrumb({
-      ...LoglevelSentry.translateMessage(msgs),
+      ...LoglevelSentry.translateArgs(args),
       category: this.category,
       level,
       timestamp: Date.now(),
     });
   }
 
-  trace(...msgs: unknown[]): void {
-    this.log(Severity.Debug, ...msgs);
+  trace(...args: unknown[]): void {
+    this.log(Severity.Debug, ...args);
   }
 
-  error(err: Error, ...msgs: unknown[]): void {
+  error(err: Error, ...args: unknown[]): void {
     this.sentry.captureException(err, {
-      tags: { logger: this.category },
-      extra: { messages: msgs },
+      tags: { logger: "loglevel-sentry", "logger.name": this.category },
+      extra: { arguments: args },
     });
   }
 
-  private static translateError(messages: unknown[]): [Error, unknown[]] {
+  private static translateError(args: unknown[]): [Error, unknown[]] {
     // Find first Error or create an "unknown" Error to keep stack trace.
-    const index = messages.findIndex((msg) => msg instanceof Error);
-    const err = index !== -1 ? (messages.splice(index, 1)[0] as Error) : new Error("unknown");
-    return [err, messages];
+    const index = args.findIndex((arg) => arg instanceof Error);
+    const err = index !== -1 ? (args.splice(index, 1)[0] as Error) : new Error("unknown");
+    return [err, args];
   }
 
-  private static translateMessage(messages: unknown[]): Pick<Breadcrumb, "data" | "message"> {
-    const [firstMsg, ...otherMsgs] = messages;
-    return typeof firstMsg === "string"
+  private static translateArgs(args: unknown[]): Pick<Breadcrumb, "data" | "message"> {
+    const [firstArg, ...otherArgs] = args;
+    return typeof firstArg === "string"
       ? {
-          message: firstMsg,
-          data: { messages: otherMsgs },
+          message: firstArg,
+          data: { arguments: otherArgs },
         }
-      : { data: { messages } };
+      : { data: { arguments: args } };
   }
 
   private static translateLevel(level: string): Severity {

--- a/types/src/create-logger.d.ts
+++ b/types/src/create-logger.d.ts
@@ -1,3 +1,3 @@
-import { Client } from "@sentry/types";
 import { Logger } from "loglevel";
-export declare function createLogger(name: string, client: Client): Logger;
+import { Sentry } from "./loglevel-sentry";
+export declare function createLogger(name: string, sentry: Sentry): Logger;

--- a/types/src/loglevel-sentry.d.ts
+++ b/types/src/loglevel-sentry.d.ts
@@ -1,9 +1,15 @@
-import { Client, Severity } from "@sentry/types";
+import { Hub } from "@sentry/core";
+import { Breadcrumb, Severity, CaptureContext } from "@sentry/types";
 import { Logger } from "loglevel";
+export interface Sentry {
+    captureException(exception: any, captureContext?: CaptureContext): string;
+    addBreadcrumb(breadcrumb: Breadcrumb): void;
+    getCurrentHub(): Hub;
+}
 export default class LoglevelSentry {
     private sentry;
     private category;
-    constructor(client: Client);
+    constructor(sentry: Sentry);
     install(logger: Logger): void;
     setEnabled(enabled: boolean): void;
     isEnabled(): boolean;

--- a/types/src/loglevel-sentry.d.ts
+++ b/types/src/loglevel-sentry.d.ts
@@ -1,5 +1,5 @@
 import { Hub } from "@sentry/core";
-import { Breadcrumb, Severity, CaptureContext } from "@sentry/types";
+import { Breadcrumb, CaptureContext, Severity } from "@sentry/types";
 import { Logger } from "loglevel";
 export interface Sentry {
     captureException(exception: any, captureContext?: CaptureContext): string;
@@ -13,10 +13,10 @@ export default class LoglevelSentry {
     install(logger: Logger): void;
     setEnabled(enabled: boolean): void;
     isEnabled(): boolean;
-    log(level: Severity, ...msgs: unknown[]): void;
-    trace(...msgs: unknown[]): void;
-    error(err: Error, ...msgs: unknown[]): void;
+    log(level: Severity, ...args: unknown[]): void;
+    trace(...args: unknown[]): void;
+    error(err: Error, ...args: unknown[]): void;
     private static translateError;
-    private static translateMessage;
+    private static translateArgs;
     private static translateLevel;
 }


### PR DESCRIPTION
Current implementation creates a new `Hub` for every new instance of the plugin, which separates the information/scope of reported events from Sentry platform implementation (`@sentry/vue`, `@sentry/node`, etc). This uses minimal Sentry platform interface instead of creating a new one from `Client`, which allows users to input their Sentry platform instances.

```js
import * as Sentry from "@sentry/vue";
// import * as Sentry from "@sentry/node";

const plugin = new LoglevelSentryPlugin(Sentry);
plugin.install(logger);
```