### PR TITLE
feat: log traceId and spanId

### DIFF
--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -1,4 +1,3 @@
-import type { Hub } from "@sentry/core";
 import type { Breadcrumb, CaptureContext, Client, Scope, SeverityLevel, Span } from "@sentry/types";
 import { normalize } from "@sentry/utils";
 import { Logger } from "loglevel";
@@ -7,7 +6,6 @@ export interface Sentry {
   getClient<C extends Client>(): C | undefined;
   captureException(exception: unknown, captureContext?: CaptureContext): string;
   addBreadcrumb(breadcrumb: Breadcrumb): void;
-  getCurrentHub(): Hub; // deprecated?
   getCurrentScope(): Scope;
   getActiveSpan(): Span | undefined;
 }

--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -100,7 +100,7 @@ export default class LoglevelSentry {
       const isFrontend = typeof window !== "undefined";
 
       const overrideDefaultMethod = (...args: unknown[]) => {
-        const { traceId, spanId } = this.sentry.getActiveSpan().spanContext() || {};
+        const { traceId, spanId } = this.sentry.getActiveSpan()?.spanContext() || {};
         const isError = method === "error" && args.length >= 1 && args[0] instanceof Error;
         if (isFrontend) {
           if (isError) {

--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -105,7 +105,7 @@ export default class LoglevelSentry {
         if (isFrontend) {
           if (isError) {
             const error = args[0] as Error;
-            const newError = new Error(`${error.message}: ${traceId} - ${spanId}`);
+            const newError = new Error(`${error.message}: ${traceId} - ${spanId}`, { cause: error });
             const newArgs = [newError, ...args.slice(1)];
             if (defaultMethod) defaultMethod(...newArgs);
             return;

--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -98,9 +98,8 @@ export default class LoglevelSentry {
       const defaultMethod = defaultMethodFactory(method, level, name);
 
       const overrideDefaultMethod = (...args: unknown[]) => {
-        const { requestId } = this.sentry.getCurrentScope().getScopeData().extra;
         const { traceId, spanId } = this.sentry.getActiveSpan()?.spanContext() || {};
-        let logData: Record<string, unknown> = { timestamp: new Date(), level: method.toUpperCase(), logger: name, requestId, traceId, spanId };
+        let logData: Record<string, unknown> = { timestamp: new Date(), level: method.toUpperCase(), logger: name, traceId, spanId };
         if (method === "error" && args.length >= 1 && args[0] instanceof Error) {
           logData = { ...logData, message: args[0].message ?? "", stack: args[0].stack, extra: args.length > 1 ? args.slice(1) : undefined };
         } else {

--- a/src/redact-data.ts
+++ b/src/redact-data.ts
@@ -1,6 +1,6 @@
 import { normalize } from "@sentry/utils";
 
-const defaultPattern = /(private|key|secret|authorization|address|email)+/i;
+const defaultPattern = /(private|key|secret|authorization|address|email|login_hint)+/i;
 
 function isHex(s: string) {
   return /^(-0x|0x)?[0-9a-f]*$/i.test(s);


### PR DESCRIPTION
- Log `traceId`, `spanId` from spanContext()
- Redact `login_hint`

Frontend log
<img width="723" alt="Screenshot 2024-04-09 at 8 15 03 AM" src="https://github.com/torusresearch/loglevel-sentry/assets/161312225/bc223519-c98a-4fff-bea2-22d9e1ef7b35">

Log with `traceId`, `spanId`
```
@toruslabs/fnd-server: fnd-server-1  | {"timestamp":"2024-04-05T08:43:34.283Z","level":"ERROR","traceId":"4791c2fc080a4dedaca7ab542133b294","message":"This is an error","stack":"Error: This is an error\n    at /app/packages/fnd-server/src/router.ts:28:11\n    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)\n    at next (/app/node_modules/express/lib/router/route.js:149:13)\n    at Route.dispatch (/app/node_modules/express/lib/router/route.js:119:3)\n    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)\n    at /app/node_modules/express/lib/router/index.js:284:15\n    at Function.process_params (/app/node_modules/express/lib/router/index.js:346:12)\n    at Function.process_params (/app/node_modules/@sentry-internal/src/node/integrations/express.ts:390:46)\n    at next (/app/node_modules/express/lib/router/index.js:280:10)\n    at Function.handle (/app/node_modules/express/lib/router/index.js:175:3)","extra":["Error while fetching nodes details"]}
```