### PR TITLE
Fix nested error message + handle Axios network error + make Sentry optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "8.0.2",
       "license": "MIT",
       "dependencies": {
+        "@sentry/core": "^9.5.0",
         "loglevel": "^1.9.2"
       },
       "devDependencies": {
-        "@sentry/core": "^9.5.0",
         "@toruslabs/config": "^3.1.0",
         "@toruslabs/eslint-config-typescript": "^4.1.0",
         "@toruslabs/torus-scripts": "^7.1.2",
@@ -28,8 +28,7 @@
         "npm": ">=9.x"
       },
       "peerDependencies": {
-        "@babel/runtime": "^7.x",
-        "@sentry/core": "^9.x"
+        "@babel/runtime": "^7.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3251,7 +3250,6 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.5.0.tgz",
       "integrity": "sha512-NMqyFdyg26ECAfnibAPKT8vvAt4zXp4R7dYtQnwJKhEJEVkgAshcNYeJ2D95ZLMVOqlqhTtTPnw1vqf+v9ePZg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -14893,8 +14891,7 @@
     "@sentry/core": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.5.0.tgz",
-      "integrity": "sha512-NMqyFdyg26ECAfnibAPKT8vvAt4zXp4R7dYtQnwJKhEJEVkgAshcNYeJ2D95ZLMVOqlqhTtTPnw1vqf+v9ePZg==",
-      "dev": true
+      "integrity": "sha512-NMqyFdyg26ECAfnibAPKT8vvAt4zXp4R7dYtQnwJKhEJEVkgAshcNYeJ2D95ZLMVOqlqhTtTPnw1vqf+v9ePZg=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",

--- a/src/create-logger.ts
+++ b/src/create-logger.ts
@@ -2,6 +2,12 @@ import loglevel, { Logger } from "loglevel";
 
 import { LoglevelSentry as SentryPlugin, Sentry } from "./loglevel-sentry";
 
+/**
+ * TODO: remove in the next major version (v10)
+ * @deprecated Use `loglevel.getLogger` instead
+ * We should not use this function as it'll install the plugin to the logger which we already do it when setting up the Sentry
+ * When we install multiple times, it'll format the error message in a nested way
+ */
 export function createLogger(name: string, sentry: Sentry): Logger {
   const logger = loglevel.getLogger(name);
   logger.enableAll();

--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -25,7 +25,6 @@ export class LoglevelSentry {
   }
 
   private static async translateError(args: unknown[]): Promise<[Error, unknown[]]> {
-    // Find first Error or create an "unknown" Error to keep stack trace.
     const index = args.findIndex((arg) => arg instanceof Error);
     const msgIndex = args.findIndex((arg) => typeof arg === "string");
     const apiErrorIdx = args.findIndex((arg) => arg && typeof arg === "object" && "status" in arg && "type" in arg);
@@ -129,7 +128,11 @@ export class LoglevelSentry {
       switch (method) {
         case "error":
           return async (...args: unknown[]) => {
+            // stack trace is lost when using async/await
+            const { stack } = new Error();
             const [err, otherArgs] = await LoglevelSentry.translateError(args);
+            // set original stack trace
+            err.stack = stack;
 
             this.error(err, ...otherArgs);
             overrideDefaultMethod(err, ...otherArgs);

--- a/src/loglevel-sentry.ts
+++ b/src/loglevel-sentry.ts
@@ -45,15 +45,19 @@ export class LoglevelSentry {
     } else if (axiosErrorIdx !== -1) {
       const axiosError = args[axiosErrorIdx] as { response: AxiosResponse };
       const errorResponse = axiosError.response;
-      const contentType = errorResponse.headers?.["content-type"];
-      if (contentType.includes("application/json")) {
-        const errJson = errorResponse.data as object;
-        const errorMsg = "error" in errJson ? errJson.error : "message" in errJson ? errJson.message : JSON.stringify(errJson);
-        err = new Error(errorMsg as string);
-      } else if (contentType.includes("text/plain")) {
-        err = new Error(errorResponse.data as string);
+      if (errorResponse) {
+        const contentType = errorResponse.headers?.["content-type"];
+        if (contentType.includes("application/json")) {
+          const errJson = errorResponse.data as object;
+          const errorMsg = "error" in errJson ? errJson.error : "message" in errJson ? errJson.message : JSON.stringify(errJson);
+          err = new Error(errorMsg as string);
+        } else if (contentType.includes("text/plain")) {
+          err = new Error(errorResponse.data as string);
+        } else {
+          err = new Error(`${errorResponse.status} ${errorResponse.data.toString()}`);
+        }
       } else {
-        err = new Error(`${errorResponse.status} ${errorResponse.data.toString()}`);
+        err = new Error("Network error");
       }
     } else if (index !== -1) {
       err = args.splice(index, 1)[0] as Error;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://toruslabs.atlassian.net/browse/PD-4499

QUESTIONS: do we need to fix v8?

## Description
<!--- Describe your changes in detail -->
- Fix nested error message: when we install the plugin multiple times, it'll cause nested error
![image](https://github.com/user-attachments/assets/b877fb7b-3bdd-47f2-8a30-b83b76740ed1)
```
{
    "timestamp": "2025-03-20T16:18:18.578Z",
    "level": "INFO",
    "logger": "adapter/smsPasswordless.ts",
    "traceId": "9355480a90ad6deee69e21cab369718a",
    "spanId": "62a4324ef4c09063",
    "message": {
        "timestamp":"2025-03-20T16:18:18.578Z",
        "level":"INFO",
        "logger":"adapter/smsPasswordless.ts",
        "traceId":"9355480a90ad6deee69e21cab369718a",
        "spanId":"62a4324ef4c09063",
        "message":"{
            "timestamp":"2025-03-20T16:18:18.577Z",
            "level":"INFO",
            "logger":"adapter/smsPasswordless.ts",
            "traceId":"9355480a90ad6deee69e21cab369718a",
            "spanId":"62a4324ef4c09063",
            "message":"email passwordless error",
            "extra":[]
        }"
    }
}
```
- handle Axios network error: when facing network error, there are no responses in the error object
![image](https://github.com/user-attachments/assets/c6edb225-c5f6-4254-bfe2-97f18e172f68)
- make Sentry optional: we want to reuse error error parsing of loglevel plugin

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires a db migration.
